### PR TITLE
Add checks for HCZ/CNZ/LBZ rotation objects (Origins accuracy)

### DIFF
--- a/Origins Animations/scripts/main.lemon
+++ b/Origins Animations/scripts/main.lemon
@@ -834,7 +834,8 @@ function void fn07eeee()
 function void fn032610()
 {
 	base.fn032610()
-	Vee_OriginsAnimations.customAnimationAddress = 0x03263e
+	if ((objA0.subtype2c == 0 || objA0.subtype2c % 0x10 == 0) || global.zone == 0x06)
+		Vee_OriginsAnimations.customAnimationAddress = 0x03263e
 }
 
 // LBZ rotating elevator


### PR DESCRIPTION
this makes it so it doesn't activate when it shouldn't (ex. pressing up or down on HCZ pillars or CNZ barrels that don't respond to user input)